### PR TITLE
Fix: preserve blank line separator when replacing Minara section on re-run

### DIFF
--- a/scripts/claudecode-minara-skill-setup.sh
+++ b/scripts/claudecode-minara-skill-setup.sh
@@ -154,6 +154,7 @@ _inject_claude_md() {
     fi
     printf '%s\n' "$CLAUDE_MD_BLOCK" >> "$tmp_claude"
     if [[ "$end_line" -lt "$total_lines" ]]; then
+      printf '\n' >> "$tmp_claude"
       tail -n +"$((end_line + 1))" "$CLAUDE_MD" >> "$tmp_claude"
     fi
     cp "$tmp_claude" "$CLAUDE_MD"

--- a/scripts/hermes-minara-skill-setup.sh
+++ b/scripts/hermes-minara-skill-setup.sh
@@ -154,6 +154,7 @@ _inject_memory_md() {
     fi
     printf '%s\n' "$MEMORY_MD_BLOCK" >> "$tmp_memory"
     if [[ "$end_line" -lt "$total_lines" ]]; then
+      printf '\n' >> "$tmp_memory"
       tail -n +"$((end_line + 1))" "$MEMORY_MD" >> "$tmp_memory"
     fi
     cp "$tmp_memory" "$MEMORY_MD"

--- a/scripts/openclaw-minara-skill-setup.sh
+++ b/scripts/openclaw-minara-skill-setup.sh
@@ -200,6 +200,7 @@ _inject_agents_prompt() {
     fi
     printf '%s\n' "$AGENTS_BLOCK" >> "$tmp_agents"
     if [[ "$end_line" -lt "$total_lines" ]]; then
+      printf '\n' >> "$tmp_agents"
       tail -n +"$((end_line + 1))" "$agents_file" >> "$tmp_agents"
     fi
     cp "$tmp_agents" "$agents_file"


### PR DESCRIPTION
## Bug

Re-running any of the three setup scripts (Claude Code / OpenClaw / Hermes)
on a config file that already has a `## Minara` section followed by other
content drops the blank line separating them, producing malformed Markdown.

Repro:
1. Create a CLAUDE.md with a `## Minara ...` section followed by `## Deployment`
2. Run `claudecode-minara-skill-setup.sh` twice
3. Result: the last line of the Minara block is glued directly to `## Deployment`
   with no blank line between them

## Fix

Add a single `printf '\n'` before splicing in the tail content, in all three
scripts (`_inject_claude_md`, `_inject_agents_prompt`, `_inject_memory_md`).

Verified: blank line restored, idempotent across repeated runs, and the
"Minara section is last in file" edge case still works correctly.